### PR TITLE
provide better handling for htmlspecialchars in build_query_args #4

### DIFF
--- a/src/Post_Type_Controller.php
+++ b/src/Post_Type_Controller.php
@@ -70,7 +70,7 @@ class Post_Type_Controller extends Base_Controller {
 
       // otherwise, just add params to $args
       } else {
-        $args[$param] = htmlspecialchars($value);
+        $args[$param] = is_string($value) ? htmlspecialchars($value) : $value;
       }
     }
 


### PR DESCRIPTION
In some cases, our older sites use request URLs which contain array syntax and are later "transformed". This transform can be performed afterwards using the cuberis_rest_api_query_args filter.